### PR TITLE
Dark theme detection

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 *.user
+build
+.clickable

--- a/clickable.json
+++ b/clickable.json
@@ -1,0 +1,12 @@
+{
+  "template": "qmake",
+  "dependencies_target": [
+    "qtquickcontrols2-5-dev",
+    "qtquickcontrols2-5-private-dev",
+    "qtdeclarative5-dev"
+  ],
+  "scripts": {
+    "push": "adb push build/tmp/usr/lib/arm-linux-gnueabihf/qt5/qml/QtQuick/Controls.2/Suru/ /home/phablet/ && adb shell \"sudo cp -r /home/phablet/Suru/ /usr/lib/arm-linux-gnueabihf/qt5/qml/QtQuick/Controls.2/\""
+  },
+  "default": "build push"
+}

--- a/qqc2-suru/qquicksurustyle.cpp
+++ b/qqc2-suru/qquicksurustyle.cpp
@@ -27,6 +27,7 @@
 
 #include <QtCore/qdebug.h>
 #include <QtCore/qsettings.h>
+#include <QtCore/qstandardpaths.h>
 #include <QtQml/qqmlinfo.h>
 #include <QtQuickControls2/private/qquickstyleattached_p.h>
 
@@ -89,7 +90,21 @@ static uint globalColors[2][9] = {
 
 static bool globalCustoms[2][9] = { { false } };
 
-extern bool qt_is_dark_system_theme();
+static const QString settingsFile = QStringLiteral("%1/ubuntu-ui-toolkit/theme.ini");
+static const QString ubuntuDarkTheme = QStringLiteral("Ubuntu.Components.Themes.SuruDark");
+
+static bool qt_is_dark_system_theme() {
+    bool is_dark = false;
+
+    // TODO make this work on OSs other than Ubuntu Touch
+    QSettings settings(settingsFile.arg(QStandardPaths::writableLocation(QStandardPaths::ConfigLocation)), QSettings::IniFormat);
+    QString themeName = settings.value(QStringLiteral("theme")).toString();
+    if (themeName == ubuntuDarkTheme) {
+        is_dark = true;
+    }
+
+    return is_dark;
+};
 
 static QQuickSuruStyle::Theme qquicksuru_effective_theme(QQuickSuruStyle::Theme theme)
 {
@@ -378,6 +393,8 @@ void QQuickSuruStyle::init()
             globalTheme = m_theme = qquicksuru_effective_theme(themeEnum);
         else if (!themeValue.isEmpty())
             qWarning().nospace().noquote() << "Suru: unknown theme value: " << themeValue;
+        else
+            globalTheme = m_theme = qquicksuru_effective_theme(QQuickSuruStyle::System);
 
         initPaletteColor(Light, Positive, "QT_QUICK_CONTROLS_SURU_LIGHT_POSITIVE", settings);
         initPaletteColor(Light, Negative, "QT_QUICK_CONTROLS_SURU_LIGHT_NEGATIVE", settings);


### PR DESCRIPTION
Detect the dark theme being set in the ubuntu touch uitk's config file. Also added a clickable setup to make it easier to test on the device.