### PR TITLE
Restore Page background

### DIFF
--- a/qqc2-suru/Page.qml
+++ b/qqc2-suru/Page.qml
@@ -39,4 +39,8 @@ T.Page {
 
     contentWidth: contentItem.implicitWidth || (contentChildren.length === 1 ? contentChildren[0].implicitWidth : 0)
     contentHeight: contentItem.implicitHeight || (contentChildren.length === 1 ? contentChildren[0].implicitHeight : 0)
+
+    background: Rectangle {
+        color: control.Suru.backgroundColor
+    }
 }


### PR DESCRIPTION
Restores Rectangle as background in Page element to comply to standard styling in qqc2

fixes #20