### PR TITLE
Removed problematic width setting in the Label component

### DIFF
--- a/qqc2-suru/Label.qml
+++ b/qqc2-suru/Label.qml
@@ -55,27 +55,4 @@ T.Label {
             return control.Suru.units.fontParagraph
         }
     }
-
-    // EXPERIMENTAL
-    width: {
-        var max_width = function () {
-            switch (control.Suru.textLevel) {
-            case Suru.HeadingOne:
-            case Suru.HeadingTwo:
-            case Suru.HeadingThree:
-            case Suru.Small:
-            case Suru.Caption:
-                return control.Suru.units.rem(35)
-            case Suru.Paragraph:
-            case Suru.CodeBlock:
-            default:
-                return control.Suru.units.rem(50)
-            }
-        }
-
-        return Math.min(parent.width, max_width())
-    }
-
-    // EXPERIMENTAL
-    lineHeight: 1.5
 }


### PR DESCRIPTION
This fixes #19.

Apparently the problem with that is that Suru was setting the width of the Label component but the width should be controlled by the Column. I checked the other QQC2 styles and none of them set the width or line height so I removed both of those properties (and they were also marked as experimental anyways).