### PR TITLE
Set the default dial background width to match the material design size

### DIFF
--- a/qqc2-suru/Dial.qml
+++ b/qqc2-suru/Dial.qml
@@ -38,7 +38,7 @@ T.Dial {
         x: control.width / 2 - width / 2
         y: control.height / 2 - height / 2
 
-        width: Math.max(192, Math.min(control.width, control.height))
+        width: Math.max(64, Math.min(control.width, control.height))
         height: width; radius: width / 2
 
         color: "transparent"


### PR DESCRIPTION
For reference: https://github.com/qt/qtquickcontrols2/blob/5.9/src/imports/controls/material/Dial.qml#L51