### PR TITLE
Set Elevation shadow to grey

### DIFF
--- a/qqc2-suru/ElevationEffect.qml
+++ b/qqc2-suru/ElevationEffect.qml
@@ -49,12 +49,12 @@ DropShadow {
     color: {
         switch(elevation) {
         case 1:
-            return "#26000000"
+            return "#56888888"
         case 2:
-            return "#40000000"
+            return "#70888888"
         case 3:
         default:
-            return "#32000000"
+            return "#62888888"
         }
     }
 }


### PR DESCRIPTION
- Set shadow color from 000 to 888 (works both on dark mode and light mode)
- Set transparency to darker to fit same look 

fixes #7 
should fix #12 

after:

![imatge](https://user-images.githubusercontent.com/6640041/70662944-94178500-1c67-11ea-98a4-dcf830b64bca.png)



before:
![imatge](https://user-images.githubusercontent.com/6640041/70662906-819d4b80-1c67-11ea-85f6-e5393eaf468a.png)
![imatge](https://user-images.githubusercontent.com/6640041/70662916-8661ff80-1c67-11ea-95ad-6b3051e3cbde.png)
