### PR TITLE
Port C++ parts to Qt 5.12

### DIFF
--- a/qqc2-suru/qquicksurustyle.cpp
+++ b/qqc2-suru/qquicksurustyle.cpp
@@ -29,7 +29,11 @@
 #include <QtCore/qsettings.h>
 #include <QtCore/qstandardpaths.h>
 #include <QtQml/qqmlinfo.h>
+#if QT_VERSION >= QT_VERSION_CHECK(5, 12, 0)
+#include <QtQuickControls2/private/qquickstyle_p.h>
+#else
 #include <QtQuickControls2/private/qquickstyleattached_p.h>
+#endif
 
 static QRgb qquicksuru_color(QQuickSuruStyle::Color colorRole)
 {
@@ -113,7 +117,11 @@ static QQuickSuruStyle::Theme qquicksuru_effective_theme(QQuickSuruStyle::Theme 
     return theme;
 }
 
+#if QT_VERSION >= QT_VERSION_CHECK(5, 12, 0)
+QQuickSuruStyle::QQuickSuruStyle(QObject *parent) : QQuickAttachedObject(parent),
+#else
 QQuickSuruStyle::QQuickSuruStyle(QObject *parent) : QQuickStyleAttached(parent),
+#endif
     m_explicitTheme(false),
     m_theme(globalTheme),
     m_highlightType(InformationHighlight),
@@ -178,8 +186,13 @@ void QQuickSuruStyle::inheritTheme(Theme theme)
 
 void QQuickSuruStyle::propagateTheme()
 {
+#if QT_VERSION >= QT_VERSION_CHECK(5, 12, 0)
+    const auto styles = attachedChildren();
+    for (QQuickAttachedObject *child : styles) {
+#else
     const auto styles = childStyles();
     for (QQuickStyleAttached *child : styles) {
+#endif
         QQuickSuruStyle *suru = qobject_cast<QQuickSuruStyle *>(child);
         if (suru)
             suru->inheritTheme(m_theme);
@@ -192,7 +205,11 @@ void QQuickSuruStyle::resetTheme()
         return;
 
     m_explicitTheme = false;
+#if QT_VERSION >= QT_VERSION_CHECK(5, 12, 0)
+    QQuickSuruStyle *suru = qobject_cast<QQuickSuruStyle *>(attachedParent());
+#else
     QQuickSuruStyle *suru = qobject_cast<QQuickSuruStyle *>(parentStyle());
+#endif
     inheritTheme(suru ? suru->theme() : globalTheme);
 }
 
@@ -271,8 +288,13 @@ void QQuickSuruStyle::inheritPaletteColor(const QQuickSuruStyle::Theme &theme, c
 
 void QQuickSuruStyle::propagatePaletteColor(const QQuickSuruStyle::Theme &theme, const QQuickSuruStyle::PaletteColor &paletteColor)
 {
+#if QT_VERSION >= QT_VERSION_CHECK(5, 12, 0)
+    const auto styles = attachedChildren();
+    for (QQuickAttachedObject *child : styles) {
+#else
     const auto styles = childStyles();
     for (QQuickStyleAttached *child : styles) {
+#endif
         QQuickSuruStyle *suru = qobject_cast<QQuickSuruStyle *>(child);
 
         if (suru)
@@ -288,7 +310,11 @@ void QQuickSuruStyle::resetPaletteColor(const QQuickSuruStyle::Theme &theme, con
     m_customs[theme][paletteColor] = false;
     m_explicits[theme][paletteColor] = false;
 
+#if QT_VERSION >= QT_VERSION_CHECK(5, 12, 0)
+    QQuickSuruStyle *suru = qobject_cast<QQuickSuruStyle *>(attachedParent());
+#else
     QQuickSuruStyle *suru = qobject_cast<QQuickSuruStyle *>(parentStyle());
+#endif
     if (suru)
         inheritPaletteColor(theme, paletteColor, suru->m_colors[theme][paletteColor], suru->m_customs[theme][paletteColor]);
     else
@@ -362,7 +388,11 @@ QColor QQuickSuruStyle::tertiaryForegroundColor() const
     return c;
 }
 
+#if QT_VERSION >= QT_VERSION_CHECK(5, 12, 0)
+void QQuickSuruStyle::attachedParentChange(QQuickAttachedObject *newParent, QQuickAttachedObject *oldParent)
+#else
 void QQuickSuruStyle::parentStyleChange(QQuickStyleAttached *newParent, QQuickStyleAttached *oldParent)
+#endif
 {
     Q_UNUSED(oldParent);
     QQuickSuruStyle *suru = qobject_cast<QQuickSuruStyle *>(newParent);
@@ -401,7 +431,11 @@ void QQuickSuruStyle::init()
 {
     static bool globalsInitialized = false;
     if (!globalsInitialized) {
+#if QT_VERSION >= QT_VERSION_CHECK(5, 12, 0)
+        QSharedPointer<QSettings> settings = QQuickStylePrivate::settings(QStringLiteral("Suru"));
+#else
         QSharedPointer<QSettings> settings = QQuickStyleAttached::settings(QStringLiteral("Suru"));
+#endif
 
         bool ok = false;
         QByteArray themeValue = resolveSetting("QT_QUICK_CONTROLS_SURU_THEME", settings, QStringLiteral("Theme"));
@@ -436,7 +470,11 @@ void QQuickSuruStyle::init()
         globalsInitialized = true;
     }
 
+#if QT_VERSION >= QT_VERSION_CHECK(5, 12, 0)
+    QQuickAttachedObject::init(); // TODO: lazy init?
+#else
     QQuickStyleAttached::init(); // TODO: lazy init?
+#endif
 }
 
 void QQuickSuruStyle::initPaletteColor(const Theme &theme, const PaletteColor &paletteColor,

--- a/qqc2-suru/qquicksurustyle_p.h
+++ b/qqc2-suru/qquicksurustyle_p.h
@@ -25,7 +25,12 @@
 #define QQUICKSURUSTYLE_P_H
 
 #include <QtGui/qcolor.h>
+#if QT_VERSION >= QT_VERSION_CHECK(5, 12, 0)
+#include <QtQuickControls2/private/qquickattachedobject_p.h>
+#else
 #include <QtQuickControls2/private/qquickstyleattached_p.h>
+#endif
+#include <QSettings>
 
 #define SURU_PALETTE_COLOR(name, theme, palettecolor) \
     Q_PROPERTY(QVariant name READ name WRITE set##name RESET reset##name NOTIFY paletteChanged FINAL) \
@@ -39,7 +44,11 @@
 class QQuickSuruAnimations;
 class QQuickSuruUnits;
 
+#if QT_VERSION >= QT_VERSION_CHECK(5, 12, 0)
+class QQuickSuruStyle : public QQuickAttachedObject
+#else
 class QQuickSuruStyle : public QQuickStyleAttached
+#endif
 {
     Q_OBJECT
 
@@ -173,7 +182,11 @@ Q_SIGNALS:
     void paletteChanged();
 
 protected:
+#if QT_VERSION >= QT_VERSION_CHECK(5, 12, 0)
+    void attachedParentChange(QQuickAttachedObject *newParent, QQuickAttachedObject *oldParent) override;
+#else
     void parentStyleChange(QQuickStyleAttached *newParent, QQuickStyleAttached *oldParent) override;
+#endif
 
 private:
     void init();

--- a/qqc2-suru/qquicksurutheme.cpp
+++ b/qqc2-suru/qquicksurutheme.cpp
@@ -24,6 +24,16 @@
 #include "qquicksurutheme_p.h"
 #include "qquicksuruunits.h"
 
+#if QT_VERSION >= QT_VERSION_CHECK(5, 12, 0)
+#include <QtQuickTemplates2/private/qquicktheme_p.h>
+
+void QQuickSuruTheme::initialize(QQuickTheme *theme)
+{
+    QQuickSuruUnits suruUnits;
+    theme->setFont(QQuickTheme::System, suruUnits.fontParagraph());
+    theme->setFont(QQuickTheme::GroupBox, suruUnits.fontSmall());
+}
+#else
 QQuickSuruTheme::QQuickSuruTheme(QPlatformTheme *theme)
     : QQuickProxyTheme(theme)
 {
@@ -66,3 +76,4 @@ const QFont *QQuickSuruTheme::font(QPlatformTheme::Font type) const
         return &m_suruUnits->fontParagraph();
     }
 }
+#endif

--- a/qqc2-suru/qquicksurutheme_p.h
+++ b/qqc2-suru/qquicksurutheme_p.h
@@ -24,6 +24,19 @@
 #ifndef QQUICKSURUTHEME_P_H
 #define QQUICKSURUTHEME_P_H
 
+#include <QtGlobal>
+
+#if QT_VERSION >= QT_VERSION_CHECK(5, 12, 0)
+#include <QtCore/qglobal.h>
+
+class QQuickTheme;
+
+class QQuickSuruTheme
+{
+public:
+    static void initialize(QQuickTheme *theme);
+};
+#else
 #include <QtGui/qfont.h>
 #include <QtQuickControls2/private/qquickproxytheme_p.h>
 
@@ -38,5 +51,6 @@ public:
 private:
     QQuickSuruUnits *m_suruUnits;
 };
+#endif
 
 #endif // QQUICKSURUTHEME_P_H

--- a/qqc2-suru/qtquickcontrols2surustyleplugin.cpp
+++ b/qqc2-suru/qtquickcontrols2surustyleplugin.cpp
@@ -28,6 +28,9 @@
 #include "qquicksuruanimations.h"
 #include "qquicksuruunits.h"
 
+#if QT_VERSION >= QT_VERSION_CHECK(5, 12, 0)
+#include <QQmlEngine>
+#else
 #include <QtQuickControls2/private/qquickcolorimageprovider_p.h>
 
 static inline void initResources()
@@ -37,6 +40,7 @@ static inline void initResources()
     Q_INIT_RESOURCE(qmake_QtQuick_Controls_2_Suru);
 #endif
 }
+#endif
 
 class QtQuickControls2SuruStylePlugin: public QQuickStylePlugin
 {
@@ -47,15 +51,25 @@ public:
     QtQuickControls2SuruStylePlugin(QObject *parent = nullptr);
 
     void registerTypes(const char *uri) override;
+#if QT_VERSION >= QT_VERSION_CHECK(5, 12, 0)
+#else
     void initializeEngine(QQmlEngine *engine, const char *uri) override;
+#endif
 
     QString name() const override;
+#if QT_VERSION >= QT_VERSION_CHECK(5, 12, 0)
+    void initializeTheme(QQuickTheme *theme) override;
+#else
     QQuickProxyTheme *createTheme() const override;
+#endif
 };
 
 QtQuickControls2SuruStylePlugin::QtQuickControls2SuruStylePlugin(QObject *parent) : QQuickStylePlugin(parent)
 {
+#if QT_VERSION >= QT_VERSION_CHECK(5, 12, 0)
+#else
     initResources();
+#endif
 }
 
 void QtQuickControls2SuruStylePlugin::registerTypes(const char *uri)
@@ -65,21 +79,31 @@ void QtQuickControls2SuruStylePlugin::registerTypes(const char *uri)
     qmlRegisterUncreatableType<QQuickSuruStyle>(uri, 2, 2, "Suru", tr("Suru is an attached property"));
 }
 
+#if QT_VERSION >= QT_VERSION_CHECK(5, 12, 0)
+#else
 void QtQuickControls2SuruStylePlugin::initializeEngine(QQmlEngine *engine, const char *uri)
 {
     QQuickStylePlugin::initializeEngine(engine, uri);
 
     engine->addImageProvider(name(), new QQuickColorImageProvider(QStringLiteral(":/qt-project.org/imports/QtQuick/Controls.2/Suru/assets")));
 }
+#endif
 
 QString QtQuickControls2SuruStylePlugin::name() const
 {
     return QStringLiteral("suru");
 }
 
+#if QT_VERSION >= QT_VERSION_CHECK(5, 12, 0)
+void QtQuickControls2SuruStylePlugin::initializeTheme(QQuickTheme *theme)
+{
+    QQuickSuruTheme::initialize(theme);
+}
+#else
 QQuickProxyTheme *QtQuickControls2SuruStylePlugin::createTheme() const
 {
     return new QQuickSuruTheme;
 }
+#endif
 
 #include "qtquickcontrols2surustyleplugin.moc"

--- a/qqc2-suru/qtquickcontrols2surustyleplugin.cpp
+++ b/qqc2-suru/qtquickcontrols2surustyleplugin.cpp
@@ -74,9 +74,29 @@ QtQuickControls2SuruStylePlugin::QtQuickControls2SuruStylePlugin(QObject *parent
 
 void QtQuickControls2SuruStylePlugin::registerTypes(const char *uri)
 {
+    qmlRegisterModule(uri, 2, 2);
+    qmlRegisterUncreatableType<QQuickSuruStyle>(uri, 2, 2, "Suru", tr("Suru is an attached property"));
+
     qmlRegisterType<QQuickSuruAnimations>();
     qmlRegisterType<QQuickSuruUnits>();
-    qmlRegisterUncreatableType<QQuickSuruStyle>(uri, 2, 2, "Suru", tr("Suru is an attached property"));
+#if QT_VERSION >= QT_VERSION_CHECK(5, 12, 0)
+    qmlRegisterType(resolvedUrl(QStringLiteral("CheckIndicator.qml")), uri, 2, 0, "CheckIndicator");
+    qmlRegisterType(resolvedUrl(QStringLiteral("CursorDelegate.qml")), uri, 2, 0, "CursorDelegate");
+    qmlRegisterType(resolvedUrl(QStringLiteral("ElevationEffect.qml")), uri, 2, 0, "ElevationEffect");
+    qmlRegisterType(resolvedUrl(QStringLiteral("HighlightFocusRectangle.qml")), uri, 2, 0, "HighlightFocusRectangle");
+    qmlRegisterType(resolvedUrl(QStringLiteral("Label.qml")), uri, 2, 0, "Label");
+    qmlRegisterType(resolvedUrl(QStringLiteral("RadioIndicator.qml")), uri, 2, 0, "RadioIndicator");
+    qmlRegisterType(resolvedUrl(QStringLiteral("SwitchIndicator.qml")), uri, 2, 0, "SwitchIndicator");
+#else
+    qmlRegisterType(typeUrl(QStringLiteral("CheckIndicator.qml")), uri, 2, 0, "CheckIndicator");
+    qmlRegisterType(typeUrl(QStringLiteral("CursorDelegate.qml")), uri, 2, 0, "CursorDelegate");
+    qmlRegisterType(typeUrl(QStringLiteral("ElevationEffect.qml")), uri, 2, 0, "ElevationEffect");
+    qmlRegisterType(typeUrl(QStringLiteral("HighlightFocusRectangle.qml")), uri, 2, 0, "HighlightFocusRectangle");
+    qmlRegisterType(typeUrl(QStringLiteral("Label.qml")), uri, 2, 0, "Label");
+    qmlRegisterType(typeUrl(QStringLiteral("RadioIndicator.qml")), uri, 2, 0, "RadioIndicator");
+    qmlRegisterType(typeUrl(QStringLiteral("SwitchIndicator.qml")), uri, 2, 0, "SwitchIndicator");
+#endif
+
 }
 
 #if QT_VERSION >= QT_VERSION_CHECK(5, 12, 0)

--- a/qqc2-suru/suru.pro
+++ b/qqc2-suru/suru.pro
@@ -5,7 +5,7 @@ IMPORT_VERSION = 2.2
 uri = QtQuick.Controls.Suru
 
 QT += gui qml quick
-QT_PRIVATE += quickcontrols2-private quick-private
+QT_PRIVATE += quickcontrols2-private quick-private quicktemplates2-private
 
 DEFINES += QT_NO_CAST_TO_ASCII QT_NO_CAST_FROM_ASCII
 
@@ -21,6 +21,5 @@ SOURCES += \
 RESOURCES += \
     $$PWD/qtquickcontrols2surustyleplugin.qrc
 
-!static: CONFIG += qmlcache
-CONFIG += no_cxx_module
+CONFIG += no_cxx_module install_qml_files builtin_resources qtquickcompiler
 load(qml_plugin)


### PR DESCRIPTION
Compatibility with Qt 5.9 is kept.

The second commit in this PR ("Add some QML type registrations") is new code for Qt 5.9, it compiles but I'm not sure if it breaks anything on 5.9, it definitely fixes loading with newer Qt versions. For example:
```
file:///usr/lib/qt/qml/QtQuick/Controls.2/Suru/Menu.qml:79 ElevationEffect is not a type
```
Please test :) Also if the second commit works fine on 5.9, **please squash the commits before merging!**