### PR TITLE
Fix missing .qml files in Qt 5.9

### DIFF
--- a/qqc2-suru/suru.pro
+++ b/qqc2-suru/suru.pro
@@ -21,5 +21,11 @@ SOURCES += \
 RESOURCES += \
     $$PWD/qtquickcontrols2surustyleplugin.qrc
 
-CONFIG += no_cxx_module install_qml_files builtin_resources qtquickcompiler
+# Qt 5.9 does not install *.qml files with the flags required for newer Qt versions
+equals(QT_MAJOR_VERSION, 5):lessThan(QT_MINOR_VERSION, 12) {
+    !static: CONFIG += qmlcache
+    CONFIG += no_cxx_module
+} else {
+    CONFIG += no_cxx_module install_qml_files builtin_resources qtquickcompiler
+}
 load(qml_plugin)


### PR DESCRIPTION
See https://github.com/ubports/qqc2-suru-style/pull/38#issuecomment-578408842

**Not confirmed that it fixes the issue**, in a Qt 5.9 docker container it does run qmlcachegen again which was run before the previous change but please confirm the contents of the .deb package :)

edit: The jenkins build has references to `Label.qml` and other qml files again so there's a high chance this fix is actually working ^^

edit 2: artifacts are done,looks good!