### PR TITLE
debian/rules: allow building with crossbuilder

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -1,5 +1,5 @@
 #!/usr/bin/make -f
-export QT_SELECT := qt5
+export QT_SELECT ?= qt5
 %:
 	dh $@ --with pkgkde_symbolshelper
 


### PR DESCRIPTION
Remove the unnecessary QT_SELECT variable, which breaks crossbuilder.